### PR TITLE
add installation metric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven { url "http://repo.spring.io/plugins-release" }
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11")
         classpath("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
+        classpath("io.spring.gradle:propdeps-plugin:0.0.9.RELEASE")
     }
 }
 
@@ -68,6 +70,7 @@ subprojects {
     apply plugin: "kotlin"
     apply plugin: "jacoco"
     apply plugin: "maven-publish"
+    apply plugin: "propdeps"
 
 
     publishing {

--- a/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/InteractiveComponentResponseExtensions.kt
+++ b/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/InteractiveComponentResponseExtensions.kt
@@ -1,0 +1,19 @@
+package io.olaph.slack.dto.jackson
+
+fun InteractiveComponentResponse.Companion.sample(): InteractiveComponentResponse {
+    return InteractiveComponentResponse("type", "token", "", "",
+            InteractiveComponentResponse.Team.sample(), InteractiveComponentResponse.User.sample(), "",
+            InteractiveComponentResponse.Channel.sample(), null, null, null, listOf(), "")
+}
+
+fun InteractiveComponentResponse.Channel.Companion.sample(): InteractiveComponentResponse.Channel {
+    return InteractiveComponentResponse.Channel("ChannelId", "ChannelName")
+}
+
+fun InteractiveComponentResponse.Team.Companion.sample(): InteractiveComponentResponse.Team {
+    return InteractiveComponentResponse.Team("TeamId", "domain", null, null)
+}
+
+fun InteractiveComponentResponse.User.Companion.sample(): InteractiveComponentResponse.User {
+    return InteractiveComponentResponse.User("UserId", "Username", null)
+}

--- a/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/group/oauth/OauthAccessExtensions.kt
+++ b/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/group/oauth/OauthAccessExtensions.kt
@@ -14,7 +14,7 @@ fun IncomingWebhook.Companion.sample(): IncomingWebhook {
 }
 
 fun SuccessFullOauthAccessResponse.Companion.sample(): SuccessFullOauthAccessResponse {
-    return SuccessFullOauthAccessResponse(true, "", "", "", "", "",
+    return SuccessFullOauthAccessResponse(true, "token", "scope", "UserId", "TeamName", "TeamId",
             IncomingWebhook.sample(),
             Bot.sample())
 }

--- a/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/InteractiveComponentResponse.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/InteractiveComponentResponse.kt
@@ -1,0 +1,57 @@
+package io.olaph.slack.dto.jackson
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.olaph.slack.dto.jackson.common.Action
+
+@JacksonDataClass
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class InteractiveComponentResponse(
+        //TODO can this really be optional?
+        @JsonProperty("type") val type: String?,
+        @JsonProperty("token") val token: String?,
+        //TODO can this really be optional?
+        @JsonProperty("action_ts") val actionTs: String?,
+        //TODO can this really be optional?
+        @JsonProperty("message_ts") val messageTs: String?,
+        @JsonProperty("team") val team: Team,
+        @JsonProperty("user") val user: User,
+        @JsonProperty("state") val state: String? = "",
+        @JsonProperty("channel") val channel: Channel,
+        //TODO can this really be optional?
+        @JsonProperty("submission") val submission: Map<String, Any>?,
+        @JsonProperty("callback_id") val callbackId: String?,
+        @JsonProperty("response_url") val responseUrl: String?,
+        @JsonProperty("actions") val actions: List<Action>? = listOf(),
+        @JsonProperty("trigger_id") val triggerId: String?) {
+
+    companion object
+
+    @JacksonDataClass
+    data class Channel(@JsonProperty("id") val id: String,
+                       @JsonProperty("name") val name: String) {
+        companion object
+    }
+
+    @JacksonDataClass
+    data class User(@JsonProperty("id") val id: String,
+                    @JsonProperty("name") val name: String,
+            //TODO can this really be optional?
+                    @JsonProperty("team_id") val teamId: String?) {
+        companion object
+    }
+
+    @JacksonDataClass
+    data class Team(@JsonProperty("id") val id: String,
+                    @JsonProperty("domain") val domain: String,
+                    @JsonProperty("enterprise_id") val enterpriseId: String?,
+                    @JsonProperty("enterprise_name") val enterpriseName: String?) {
+        companion object
+    }
+}
+
+
+
+
+
+

--- a/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/group/dialog/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/group/dialog/Open.kt
@@ -1,11 +1,9 @@
 package io.olaph.slack.dto.jackson.group.dialog
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.olaph.slack.dto.jackson.JacksonDataClass
-import io.olaph.slack.dto.jackson.common.Action
 
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
@@ -55,37 +53,3 @@ abstract class Element(@JsonProperty("label") open val label: String,
                        @JsonProperty("type") open val type: Type,
                        @JsonProperty("name") open val name: String)
 
-@JacksonDataClass
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class InteractiveComponentResponse(
-        @JsonProperty("type") val type: String?,
-        @JsonProperty("token") val token: String?,
-        //TODO can this really be optional?
-        @JsonProperty("action_ts") val actionTs: String?,
-        //TODO can this really be optional?
-        @JsonProperty("message_ts") val messageTs: String?,
-        @JsonProperty("team") val team: Team,
-        @JsonProperty("user") val user: User,
-        @JsonProperty("state") val state: String? = "",
-        @JsonProperty("channel") val channel: Channel,
-        //TODO can this really be optional?
-        @JsonProperty("submission") val submission: Map<String, Any>?,
-        @JsonProperty("callback_id") val callbackId: String?,
-        @JsonProperty("response_url") val responseUrl: String?,
-        @JsonProperty("actions") val actions: List<Action>? = listOf(),
-        @JsonProperty("trigger_id") val triggerId: String?)
-
-@JacksonDataClass
-data class Channel(@JsonProperty("id") val id: String,
-                   @JsonProperty("name") val name: String)
-
-@JacksonDataClass
-data class User(@JsonProperty("id") val id: String,
-                @JsonProperty("name") val name: String,
-                @JsonProperty("team_id") val teamId: String?)
-
-@JacksonDataClass
-data class Team(@JsonProperty("id") val id: String,
-                @JsonProperty("domain") val domain: String,
-                @JsonProperty("enterprise_id") val enterpriseId: String?,
-                @JsonProperty("enterprise_name") val enterpriseName: String?)

--- a/samples/slack-spring-boot-starter-sample/build.gradle
+++ b/samples/slack-spring-boot-starter-sample/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation(project(":slack-spring-boot-starter"))
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/samples/slack-spring-boot-starter-sample/src/main/resources/application.properties
+++ b/samples/slack-spring-boot-starter-sample/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+debug=true
+management.endpoints.web.exposure.include=health,info,metrics
 slack.installation.success-redirect-url=
 slack.installation.error-redirect-url=
 slack.installation.client-id=

--- a/starter/slack-spring-boot-autoconfigure/build.gradle
+++ b/starter/slack-spring-boot-autoconfigure/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation(group: "org.springframework.boot", name: "spring-boot")
     implementation(group: "org.springframework.boot", name: "spring-boot-starter-web")
     implementation(group: "org.springframework.boot", name: "spring-boot-autoconfigure")
+    optional(group: "org.springframework.boot", name: "spring-boot-starter-actuator")
 
     compileOnly(group: "org.springframework.boot", name: "spring-boot-configuration-processor")
     annotationProcessor(group: "org.springframework.boot", name: "spring-boot-configuration-processor")
@@ -27,5 +28,6 @@ dependencies {
     testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-test", version: "${springBootVersion}") {
         exclude(group: "junit", module: "junit")
     }
+    testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-actuator")
 
 }

--- a/starter/slack-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/starter/slack-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=io.olaph.slack.broker.autoconfiguration.SlackBrokerAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.olaph.slack.broker.autoconfiguration.SlackBrokerAutoConfiguration

--- a/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/BrokerAutoConfigurationTests.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/BrokerAutoConfigurationTests.kt
@@ -37,10 +37,10 @@ class BrokerAutoConfigurationTests {
 
     @DisplayName("SlackArgumentResolver Registration")
     @Test
-    fun slackCommandArgumentResolverRegistration() {
+    fun slackArgumentResolverRegistrations() {
         contextRunner.run {
             val listOf = ArrayList<HandlerMethodArgumentResolver>()
-            val bean = it.getBean<WebMvcConfigurer>("io.olaph.slack.broker.autoconfiguration.SlackBrokerAutoConfiguration\$BrokerConfiguration")
+            val bean = it.getBean<WebMvcConfigurer>("io.olaph.slack.broker.autoconfiguration.SlackBrokerAutoConfiguration\$BrokerAutoConfiguration")
 
             bean.addArgumentResolvers(listOf)
             assertTrue(listOf[0] is SlackCommandArgumentResolver)

--- a/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/MetricsAutoConfigurationTests.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/MetricsAutoConfigurationTests.kt
@@ -1,0 +1,185 @@
+package io.olaph.slack.broker.autoconfiguration
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.olaph.slack.broker.broker.CommandBroker
+import io.olaph.slack.broker.broker.EventBroker
+import io.olaph.slack.broker.broker.InstallationBroker
+import io.olaph.slack.broker.broker.InteractiveComponentBroker
+import io.olaph.slack.broker.metrics.CommandMetricsCollector
+import io.olaph.slack.broker.metrics.EventMetricsCollector
+import io.olaph.slack.broker.metrics.InstallationMetrics
+import io.olaph.slack.broker.metrics.InteractiveComponentMetricsCollector
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+@DisplayName("Test Installation Auto configuration")
+class MetricsAutoConfigurationTests {
+
+
+    @Nested
+    @DisplayName("Installation Metrics AutoConfiguration")
+    class InstallationMetricTests {
+
+        @DisplayName("InstallationMetrics Registration")
+        @Test
+        fun installationMetricsRegistration() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertDoesNotThrow { it.getBean(InstallationMetrics::class.java) }
+                    }
+        }
+
+        @DisplayName("InstallationBroker Registration Without Micrometer")
+        @Test
+        fun installationMetricsRegistrationWithoutMicrometer() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withClassLoader(FilteredClassLoader(MeterRegistry::class.java))
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertThrows(NoSuchBeanDefinitionException::class.java) { it.getBean(InstallationMetrics::class.java) }
+                        Assertions.assertDoesNotThrow { it.getBean(InstallationBroker::class.java) }
+                    }
+
+        }
+    }
+
+    @Nested
+    @DisplayName("Event Metrics AutoConfiguration")
+    class EventMetricsTests {
+
+        @DisplayName("EventMetrics Registration")
+        @Test
+        fun eventMetricsRegistration() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertDoesNotThrow { it.getBean(EventMetricsCollector::class.java) }
+                    }
+        }
+
+        @DisplayName("EventBroker Registration Without Micrometer")
+        @Test
+        fun eventMetricsRegistrationWithoutMicrometer() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withClassLoader(FilteredClassLoader(MeterRegistry::class.java))
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertThrows(NoSuchBeanDefinitionException::class.java) { it.getBean(EventMetricsCollector::class.java) }
+                        Assertions.assertDoesNotThrow { it.getBean(EventBroker::class.java) }
+                    }
+
+        }
+    }
+
+    @Nested
+    @DisplayName("Command Metrics AutoConfiguration")
+    class CommandMetricsTests {
+
+        @DisplayName("CommandMetrics Registration")
+        @Test
+        fun commandMetricsRegistration() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertDoesNotThrow { it.getBean(CommandMetricsCollector::class.java) }
+                    }
+        }
+
+        @DisplayName("CommandBroker Registration Without Micrometer")
+        @Test
+        fun commandMetricsRegistrationWithoutMicrometer() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withClassLoader(FilteredClassLoader(MeterRegistry::class.java))
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertThrows(NoSuchBeanDefinitionException::class.java) { it.getBean(CommandMetricsCollector::class.java) }
+                        Assertions.assertDoesNotThrow { it.getBean(CommandBroker::class.java) }
+                    }
+
+        }
+    }
+
+    @Nested
+    @DisplayName("Command Metrics AutoConfiguration")
+    class InteractiveComponentMetricsTests {
+
+        @DisplayName("CommandMetrics Registration")
+        @Test
+        fun interactiveComponentMetricsRegistration() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertDoesNotThrow { it.getBean(CommandMetricsCollector::class.java) }
+                    }
+        }
+
+        @DisplayName("CommandBroker Registration Without Micrometer")
+        @Test
+        fun interactiveComponentMetricsRegistrationWithoutMicrometer() {
+            ApplicationContextRunner()
+                    .withSystemProperties(
+                            "slack.installation.error-redirect-url:http://localhost:8080/installation/error",
+                            "slack.installation.success-redirect-url:http://localhost:8080/installation/success",
+                            "slack.installation.client-id:123",
+                            "slack.installation.client-secret:1234"
+                    )
+                    .withClassLoader(FilteredClassLoader(MeterRegistry::class.java))
+                    .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                    .run {
+                        Assertions.assertThrows(NoSuchBeanDefinitionException::class.java) { it.getBean(InteractiveComponentMetricsCollector::class.java) }
+                        Assertions.assertDoesNotThrow { it.getBean(InteractiveComponentBroker::class.java) }
+                    }
+
+        }
+    }
+}

--- a/starter/slack-spring-boot/build.gradle
+++ b/starter/slack-spring-boot/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
     testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-web")
     testImplementation(group: "io.micrometer", name: "micrometer-core")
+    testImplementation(project(":slack-jackson-dto-test"))
 }

--- a/starter/slack-spring-boot/build.gradle
+++ b/starter/slack-spring-boot/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-web")
     testImplementation(group: "io.micrometer", name: "micrometer-core")
     testImplementation(project(":slack-jackson-dto-test"))
+    testImplementation(project(":slack-spring-test-api-client"))
 }

--- a/starter/slack-spring-boot/build.gradle
+++ b/starter/slack-spring-boot/build.gradle
@@ -13,12 +13,16 @@ dependencies {
     api(project(":slack-jackson-dto"))
     api(project(":slack-spring-api-client"))
 
-    implementation(group: "org.springframework.boot", name: "spring-boot-starter-logging")
-    implementation(group: "org.springframework.boot", name: "spring-boot-starter-web")
-    implementation(group: "org.springframework.boot", name: "spring-boot-starter-websocket")
+    compileOnly(group: "org.springframework.boot", name: "spring-boot-starter-logging")
+    compileOnly(group: "org.springframework.boot", name: "spring-boot-starter-web")
+    compileOnly(group: "io.micrometer", name: "micrometer-core")
+
     implementation(group: "commons-codec", name: "commons-codec", version: "1.12")
     implementation(group: "commons-io", name: "commons-io", version: "2.6")
 
     implementation(group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8")
     implementation(group: "org.jetbrains.kotlin", name: "kotlin-reflect")
+
+    testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-web")
+    testImplementation(group: "io.micrometer", name: "micrometer-core")
 }

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/CommandBroker.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/CommandBroker.kt
@@ -1,9 +1,11 @@
 package io.olaph.slack.broker.broker
 
 import io.olaph.slack.broker.configuration.Command
+import io.olaph.slack.broker.metrics.CommandMetricsCollector
 import io.olaph.slack.broker.receiver.SlashCommandReceiver
 import io.olaph.slack.broker.store.TeamStore
 import io.olaph.slack.dto.jackson.SlackCommand
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -14,16 +16,31 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class CommandBroker constructor(private val slackCommandReceivers: List<SlashCommandReceiver>,
-                                private val teamStore: TeamStore) {
+                                private val teamStore: TeamStore,
+                                private val metricsCollector: CommandMetricsCollector?) {
+
+    companion object {
+        val LOG = LoggerFactory.getLogger(CommandBroker::class.java)
+    }
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/commands", consumes = ["application/x-www-form-urlencoded"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun receiveCommand(@Command slackCommand: SlackCommand, @RequestHeader headers: HttpHeaders) {
+
+        this.metricsCollector?.commandsReceived()
+
         val team = this.teamStore.findById(slackCommand.teamId)
         slackCommandReceivers
                 .filter { broker -> broker.supportsCommand(slackCommand) }
                 .forEach { broker ->
-                    broker.onReceiveSlashCommand(slackCommand, headers, team)
+                    try {
+                        this.metricsCollector?.receiverExecuted()
+                        broker.onReceiveSlashCommand(slackCommand, headers, team)
+                    } catch (e: Exception) {
+                        this.metricsCollector?.receiverExecutionError()
+                        LOG.error("{}",e)
+                    }
+
                 }
     }
 }

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/CommandBroker.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/CommandBroker.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CommandBroker constructor(private val slackCommandReceivers: List<SlashCommandReceiver>,
                                 private val teamStore: TeamStore,
-                                private val metricsCollector: CommandMetricsCollector?) {
+                                private val metricsCollector: CommandMetricsCollector? = null) {
 
     companion object {
         val LOG = LoggerFactory.getLogger(CommandBroker::class.java)
@@ -38,7 +38,7 @@ class CommandBroker constructor(private val slackCommandReceivers: List<SlashCom
                         broker.onReceiveSlashCommand(slackCommand, headers, team)
                     } catch (e: Exception) {
                         this.metricsCollector?.receiverExecutionError()
-                        LOG.error("{}",e)
+                        LOG.error("{}", e)
                     }
 
                 }

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/EventBroker.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/EventBroker.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class EventBroker constructor(private val slackEventReceivers: List<EventReceiver>,
                               private val teamStore: TeamStore,
-                              private val metricsCollector: EventMetricsCollector?) {
+                              private val metricsCollector: EventMetricsCollector? = null) {
 
     companion object {
         val LOG = LoggerFactory.getLogger(EventBroker::class.java)

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/InteractiveComponentBroker.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/broker/InteractiveComponentBroker.kt
@@ -4,7 +4,7 @@ import io.olaph.slack.broker.configuration.InteractiveResponse
 import io.olaph.slack.broker.metrics.InteractiveComponentMetricsCollector
 import io.olaph.slack.broker.receiver.InteractiveComponentReceiver
 import io.olaph.slack.broker.store.TeamStore
-import io.olaph.slack.dto.jackson.group.dialog.InteractiveComponentResponse
+import io.olaph.slack.dto.jackson.InteractiveComponentResponse
 import io.olaph.slack.dto.jackson.group.interactive_component.InteractiveComponentMessageResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class InteractiveComponentBroker constructor(private val slackInteractiveComponentReceivers: List<InteractiveComponentReceiver>,
                                              private val teamStore: TeamStore,
-                                             private val metricsCollector: InteractiveComponentMetricsCollector?) {
+                                             private val metricsCollector: InteractiveComponentMetricsCollector? = null) {
 
     companion object {
         val LOG = LoggerFactory.getLogger(InteractiveComponentBroker::class.java)

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/configuration/InteractiveResponseArgumentResolver.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/configuration/InteractiveResponseArgumentResolver.kt
@@ -2,7 +2,7 @@ package io.olaph.slack.broker.configuration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.olaph.slack.broker.security.VerificationMethodArgumentResolver
-import io.olaph.slack.dto.jackson.group.dialog.InteractiveComponentResponse
+import io.olaph.slack.dto.jackson.InteractiveComponentResponse
 import org.springframework.core.MethodParameter
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.method.support.ModelAndViewContainer

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/CommandMetrics.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/CommandMetrics.kt
@@ -1,0 +1,51 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+
+interface CommandMetricsCollector {
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecuted()
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecutionError()
+
+    /**
+     * Increments commands received metric
+     */
+    fun commandsReceived()
+}
+
+class CommandMetrics : MeterBinder, CommandMetricsCollector {
+
+    private lateinit var commandReceiverExecutionErrors: Counter
+    private lateinit var commandReceiverExecutions: Counter
+    private lateinit var commandsReceived: Counter
+
+    override fun bindTo(registry: MeterRegistry) {
+
+        commandsReceived = Counter.builder("slack.commands.received")
+                .description("Total number of commands received")
+                .register(registry)
+
+        commandReceiverExecutions = Counter.builder("slack.commands.receiver.executions")
+                .description("Total number of command receivers executions")
+                .register(registry)
+
+        commandReceiverExecutionErrors = Counter.builder("slack.commands.receiver.errors")
+                .description("Number of errors during command receiver execution")
+                .register(registry)
+    }
+
+    override fun receiverExecuted() = this.commandReceiverExecutions.increment()
+
+    override fun receiverExecutionError() = this.commandReceiverExecutionErrors.increment()
+
+    override fun commandsReceived() = this.commandsReceived.increment()
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/EventMetrics.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/EventMetrics.kt
@@ -1,0 +1,51 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+
+interface EventMetricsCollector {
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecuted()
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecutionError()
+
+    /**
+     * Increments events received metric
+     */
+    fun eventsReceived()
+}
+
+class EventMetrics : MeterBinder, EventMetricsCollector {
+
+    private lateinit var eventReceiverExecutionErrors: Counter
+    private lateinit var eventReceiverExecutions: Counter
+    private lateinit var eventsReceivedCounter: Counter
+
+    override fun bindTo(registry: MeterRegistry) {
+
+        eventsReceivedCounter = Counter.builder("slack.events.received")
+                .description("Total number of events received")
+                .register(registry)
+
+        eventReceiverExecutions = Counter.builder("slack.events.receiver.executions")
+                .description("Total number of event receivers executions")
+                .register(registry)
+
+        eventReceiverExecutionErrors = Counter.builder("slack.events.receiver.errors")
+                .description("Number of errors during event receiver execution")
+                .register(registry)
+    }
+
+    override fun receiverExecuted() = this.eventReceiverExecutions.increment()
+
+    override fun receiverExecutionError() = this.eventReceiverExecutionErrors.increment()
+
+    override fun eventsReceived() = this.eventsReceivedCounter.increment()
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InstallationMetrics.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InstallationMetrics.kt
@@ -1,0 +1,62 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+
+
+interface InstallationMetricsCollector {
+    /**
+     * Increments successful installation metric
+     */
+    fun successfulInstallation()
+
+    /**
+     * Increments error during installation metric
+     */
+    fun errorDuringInstallation()
+
+
+    /**
+     * Increments installation attempt metric
+     */
+    fun installationAttempt()
+}
+
+class InstallationMetrics : MeterBinder, InstallationMetricsCollector {
+
+    private lateinit var installationSuccessCounter: Counter
+    private lateinit var installationErrorCounter: Counter
+    private lateinit var installationCounter: Counter
+
+    override fun bindTo(registry: MeterRegistry) {
+
+        installationSuccessCounter = Counter.builder("slack.installation.success")
+                .description("Number of successful installations")
+                .register(registry)
+
+        installationErrorCounter = Counter.builder("slack.installation.error")
+                .description("Number of errors during installations")
+                .register(registry)
+
+        installationCounter = Counter.builder("slack.installation.count")
+                .description("Number of installation attempts")
+                .register(registry)
+    }
+
+    /**
+     * Increments successful installation metric
+     */
+    override fun successfulInstallation() = installationSuccessCounter.increment()
+
+    /**
+     * Increments error during installation metric
+     */
+    override fun errorDuringInstallation() = installationErrorCounter.increment()
+
+
+    /**
+     * Increments installation attempt metric
+     */
+    override fun installationAttempt() = installationCounter.increment()
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InstallationMetrics.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InstallationMetrics.kt
@@ -21,6 +21,16 @@ interface InstallationMetricsCollector {
      * Increments installation attempt metric
      */
     fun installationAttempt()
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecuted()
+
+    /**
+     * Increments receiver execution metric
+     */
+    fun receiverExecutionError()
 }
 
 class InstallationMetrics : MeterBinder, InstallationMetricsCollector {
@@ -28,6 +38,8 @@ class InstallationMetrics : MeterBinder, InstallationMetricsCollector {
     private lateinit var installationSuccessCounter: Counter
     private lateinit var installationErrorCounter: Counter
     private lateinit var installationCounter: Counter
+    private lateinit var installationReceiverExecutionErrors: Counter
+    private lateinit var installationReceiverExecutions: Counter
 
     override fun bindTo(registry: MeterRegistry) {
 
@@ -42,21 +54,23 @@ class InstallationMetrics : MeterBinder, InstallationMetricsCollector {
         installationCounter = Counter.builder("slack.installation.count")
                 .description("Number of installation attempts")
                 .register(registry)
+
+        installationReceiverExecutions = Counter.builder("slack.installation.receiver.executions")
+                .description("Total number of installation receivers executions")
+                .register(registry)
+
+        installationReceiverExecutionErrors = Counter.builder("slack.installation.receiver.errors")
+                .description("Number of errors during installation receiver execution")
+                .register(registry)
     }
 
-    /**
-     * Increments successful installation metric
-     */
     override fun successfulInstallation() = installationSuccessCounter.increment()
 
-    /**
-     * Increments error during installation metric
-     */
     override fun errorDuringInstallation() = installationErrorCounter.increment()
 
-
-    /**
-     * Increments installation attempt metric
-     */
     override fun installationAttempt() = installationCounter.increment()
+
+    override fun receiverExecuted() = installationReceiverExecutions.increment()
+
+    override fun receiverExecutionError() = installationReceiverExecutionErrors.increment()
 }

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetrics.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetrics.kt
@@ -1,0 +1,51 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+
+interface InteractiveComponentMetricsCollector {
+
+    /**
+     * Increments receivers executed metric
+     */
+    fun receiverExecuted()
+
+    /**
+     * Increments execution error metric
+     */
+    fun receiverExecutionError()
+
+    /**
+     * Increments received metric
+     */
+    fun responseReceived()
+}
+
+class InteractiveComponentMetrics : MeterBinder, InteractiveComponentMetricsCollector {
+
+    private lateinit var responseReceiverExecutionErrors: Counter
+    private lateinit var responseReceiverExecutions: Counter
+    private lateinit var responseReceived: Counter
+
+    override fun bindTo(registry: MeterRegistry) {
+
+        responseReceived = Counter.builder("slack.interactive.received")
+                .description("Total number of interactive components received")
+                .register(registry)
+
+        responseReceiverExecutions = Counter.builder("slack.interactive.receiver.executions")
+                .description("Total number of interactive component receivers executions")
+                .register(registry)
+
+        responseReceiverExecutionErrors = Counter.builder("slack.interactive.receiver.errors")
+                .description("Number of errors during interactive component receiver execution")
+                .register(registry)
+    }
+
+    override fun receiverExecuted() = this.responseReceiverExecutions.increment()
+
+    override fun receiverExecutionError() = this.responseReceiverExecutionErrors.increment()
+
+    override fun responseReceived() = this.responseReceived.increment()
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/receiver/InteractiveComponentReceiver.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/receiver/InteractiveComponentReceiver.kt
@@ -1,7 +1,7 @@
 package io.olaph.slack.broker.receiver
 
 import io.olaph.slack.broker.store.Team
-import io.olaph.slack.dto.jackson.group.dialog.InteractiveComponentResponse
+import io.olaph.slack.dto.jackson.InteractiveComponentResponse
 import org.springframework.http.HttpHeaders
 
 interface InteractiveComponentReceiver {

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/receiver/SL4JLoggingReceiver.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/receiver/SL4JLoggingReceiver.kt
@@ -3,7 +3,7 @@ package io.olaph.slack.broker.receiver
 import io.olaph.slack.broker.store.Team
 import io.olaph.slack.dto.jackson.SlackCommand
 import io.olaph.slack.dto.jackson.SlackEvent
-import io.olaph.slack.dto.jackson.group.dialog.InteractiveComponentResponse
+import io.olaph.slack.dto.jackson.InteractiveComponentResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
@@ -31,18 +31,21 @@ data class Team(val teamId: String,
                 val teamName: String,
                 val incomingWebhook: IncomingWebhook,
                 val bot: Bot) {
+    companion object {}
 
     data class Bot(
             val userId: String,
-            val accessToken: String
-    )
+            val accessToken: String) {
+        companion object {}
+    }
 
     data class IncomingWebhook(
             val channel: String,
             val channelId: String,
             val configurationUrl: String,
-            val url: String
-    )
+            val url: String) {
+        companion object {}
+    }
 }
 
 /**

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
@@ -36,7 +36,7 @@ data class Team(val teamId: String,
     data class Bot(
             val userId: String,
             val accessToken: String) {
-        companion object {}
+        companion object
     }
 
     data class IncomingWebhook(
@@ -44,7 +44,7 @@ data class Team(val teamId: String,
             val channelId: String,
             val configurationUrl: String,
             val url: String) {
-        companion object {}
+        companion object
     }
 }
 

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/CommandBrokerTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/CommandBrokerTests.kt
@@ -1,0 +1,84 @@
+package io.olaph.slack.broker.broker
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.olaph.slack.broker.extensions.sample
+import io.olaph.slack.broker.metrics.CommandMetrics
+import io.olaph.slack.broker.receiver.SlashCommandReceiver
+import io.olaph.slack.broker.store.InMemoryTeamStore
+import io.olaph.slack.broker.store.Team
+import io.olaph.slack.dto.jackson.SlackCommand
+import io.olaph.slack.dto.jackson.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+
+class CommandBrokerTests {
+
+
+    @Test
+    @DisplayName("Broker Test")
+    fun brokerTest() {
+
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val commandMetrics = CommandMetrics()
+
+        val meterRegistry = SimpleMeterRegistry()
+        commandMetrics.bindTo(meterRegistry)
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+        CommandBroker(listOf(successReceiver, errorReceiver), teamStore, commandMetrics).receiveCommand(SlackCommand.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
+
+        Assertions.assertTrue(successReceiver.executed)
+        Assertions.assertTrue(errorReceiver.executed)
+
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.commands.received").counter().count())
+        Assertions.assertEquals(2.0, meterRegistry.get("slack.commands.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.commands.receiver.errors").counter().count())
+    }
+
+
+    @Test
+    @DisplayName("Broker Test Without Metrics")
+    fun brokerTestWithoutMetrics() {
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+        CommandBroker(listOf(successReceiver, errorReceiver), teamStore).receiveCommand(SlackCommand.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
+
+        Assertions.assertTrue(successReceiver.executed)
+        Assertions.assertTrue(errorReceiver.executed)
+    }
+
+    class SuccessReceiver : SlashCommandReceiver {
+
+        var executed: Boolean = false
+
+        override fun onReceiveSlashCommand(slackCommand: SlackCommand, headers: HttpHeaders, team: Team) {
+            executed = true
+        }
+
+    }
+
+    class ErrorReceiver : SlashCommandReceiver {
+
+        var executed: Boolean = false
+
+        override fun onReceiveSlashCommand(slackCommand: SlackCommand, headers: HttpHeaders, team: Team) {
+            executed = true
+            throw IllegalStateException("Failing Test Case")
+        }
+
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/EventBrokerTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/EventBrokerTests.kt
@@ -2,46 +2,45 @@ package io.olaph.slack.broker.broker
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.olaph.slack.broker.extensions.sample
-import io.olaph.slack.broker.metrics.CommandMetrics
-import io.olaph.slack.broker.receiver.SlashCommandReceiver
+import io.olaph.slack.broker.metrics.EventMetrics
+import io.olaph.slack.broker.receiver.EventReceiver
 import io.olaph.slack.broker.store.InMemoryTeamStore
 import io.olaph.slack.broker.store.Team
-import io.olaph.slack.dto.jackson.SlackCommand
+import io.olaph.slack.dto.jackson.SlackEvent
 import io.olaph.slack.dto.jackson.sample
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 
-@DisplayName("Command Broker Tests")
-class CommandBrokerTests {
+@DisplayName("Event Broker Tests")
+class EventBrokerTests {
 
 
     @Test
     @DisplayName("Broker Test")
     fun brokerTest() {
 
-
         val teamStore = InMemoryTeamStore()
 
         teamStore.put(Team.sample().copy(teamId = "TestId"))
 
-        val commandMetrics = CommandMetrics()
+        val metrics = EventMetrics()
 
         val meterRegistry = SimpleMeterRegistry()
-        commandMetrics.bindTo(meterRegistry)
+        metrics.bindTo(meterRegistry)
 
         val successReceiver = SuccessReceiver()
         val errorReceiver = ErrorReceiver()
 
-        CommandBroker(listOf(successReceiver, errorReceiver), teamStore, commandMetrics).receiveCommand(SlackCommand.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
+        EventBroker(listOf(successReceiver, errorReceiver), teamStore, metrics).receiveEvents(SlackEvent.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
 
         Assertions.assertTrue(successReceiver.executed)
         Assertions.assertTrue(errorReceiver.executed)
 
-        Assertions.assertEquals(1.0, meterRegistry.get("slack.commands.received").counter().count())
-        Assertions.assertEquals(2.0, meterRegistry.get("slack.commands.receiver.executions").counter().count())
-        Assertions.assertEquals(1.0, meterRegistry.get("slack.commands.receiver.errors").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.events.received").counter().count())
+        Assertions.assertEquals(2.0, meterRegistry.get("slack.events.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.events.receiver.errors").counter().count())
     }
 
 
@@ -53,30 +52,36 @@ class CommandBrokerTests {
 
         teamStore.put(Team.sample().copy(teamId = "TestId"))
 
+        val metrics = EventMetrics()
+
+        val meterRegistry = SimpleMeterRegistry()
+        metrics.bindTo(meterRegistry)
+
         val successReceiver = SuccessReceiver()
         val errorReceiver = ErrorReceiver()
 
-        CommandBroker(listOf(successReceiver, errorReceiver), teamStore).receiveCommand(SlackCommand.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
+        EventBroker(listOf(successReceiver, errorReceiver), teamStore, metrics).receiveEvents(SlackEvent.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
 
         Assertions.assertTrue(successReceiver.executed)
         Assertions.assertTrue(errorReceiver.executed)
     }
 
-    class SuccessReceiver : SlashCommandReceiver {
+    class SuccessReceiver : EventReceiver {
 
         var executed: Boolean = false
 
-        override fun onReceiveSlashCommand(slackCommand: SlackCommand, headers: HttpHeaders, team: Team) {
+        override fun onReceiveEvent(slackEvent: SlackEvent, headers: HttpHeaders, team: Team) {
             executed = true
         }
 
+
     }
 
-    class ErrorReceiver : SlashCommandReceiver {
+    class ErrorReceiver : EventReceiver {
 
         var executed: Boolean = false
 
-        override fun onReceiveSlashCommand(slackCommand: SlackCommand, headers: HttpHeaders, team: Team) {
+        override fun onReceiveEvent(slackEvent: SlackEvent, headers: HttpHeaders, team: Team) {
             executed = true
             throw IllegalStateException("Failing Test Case")
         }

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/EventBrokerTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/EventBrokerTests.kt
@@ -52,15 +52,10 @@ class EventBrokerTests {
 
         teamStore.put(Team.sample().copy(teamId = "TestId"))
 
-        val metrics = EventMetrics()
-
-        val meterRegistry = SimpleMeterRegistry()
-        metrics.bindTo(meterRegistry)
-
         val successReceiver = SuccessReceiver()
         val errorReceiver = ErrorReceiver()
 
-        EventBroker(listOf(successReceiver, errorReceiver), teamStore, metrics).receiveEvents(SlackEvent.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
+        EventBroker(listOf(successReceiver, errorReceiver), teamStore).receiveEvents(SlackEvent.sample().copy(teamId = "TestId"), HttpHeaders.EMPTY)
 
         Assertions.assertTrue(successReceiver.executed)
         Assertions.assertTrue(errorReceiver.executed)

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/InstallationBrokerTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/InstallationBrokerTests.kt
@@ -1,0 +1,116 @@
+package io.olaph.slack.broker.broker
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.olaph.slack.broker.extensions.sample
+import io.olaph.slack.broker.metrics.InstallationMetrics
+import io.olaph.slack.broker.receiver.InstallationReceiver
+import io.olaph.slack.broker.store.InMemoryTeamStore
+import io.olaph.slack.broker.store.Team
+import io.olaph.slack.client.test.MockSlackClient
+import io.olaph.slack.dto.jackson.group.oauth.ErrorOauthAccessResponse
+import io.olaph.slack.dto.jackson.group.oauth.SuccessFullOauthAccessResponse
+import io.olaph.slack.dto.jackson.group.oauth.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Installation Test Broker Tests")
+class InstallationBrokerTests {
+
+
+    @Test
+    @DisplayName("SuccessFul Installation")
+    fun successfulInstallation() {
+
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val metrics = InstallationMetrics()
+
+        val meterRegistry = SimpleMeterRegistry()
+        metrics.bindTo(meterRegistry)
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+
+        val mockSlackClient = MockSlackClient()
+
+        mockSlackClient.oauth().access().successResponse = SuccessFullOauthAccessResponse.sample()
+
+        InstallationBroker(listOf(successReceiver, errorReceiver), metrics, teamStore, mockSlackClient, InstallationBroker.Config("someClientId", "", "", ""))
+                .onInstall("code", "state")
+
+        InstallationBroker(listOf(successReceiver, errorReceiver), null, teamStore, mockSlackClient, InstallationBroker.Config("someClientId", "", "", ""))
+                .onInstall("code", "state")
+
+        Assertions.assertTrue(successReceiver.executed)
+        Assertions.assertTrue(errorReceiver.executed)
+
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.installation.success").counter().count())
+        Assertions.assertEquals(0.0, meterRegistry.get("slack.installation.error").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.installation.count").counter().count())
+        Assertions.assertEquals(2.0, meterRegistry.get("slack.installation.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.installation.receiver.errors").counter().count())
+    }
+
+    @Test
+    @DisplayName("Error Installation")
+    fun errorInstallation() {
+
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val metrics = InstallationMetrics()
+
+        val meterRegistry = SimpleMeterRegistry()
+        metrics.bindTo(meterRegistry)
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+
+        val mockSlackClient = MockSlackClient()
+
+        mockSlackClient.oauth().access().failureResponse = ErrorOauthAccessResponse.sample()
+
+        InstallationBroker(listOf(successReceiver, errorReceiver), metrics, teamStore, mockSlackClient, InstallationBroker.Config("someClientId", "", "", ""))
+                .onInstall("code", "state")
+
+        InstallationBroker(listOf(successReceiver, errorReceiver), null, teamStore, mockSlackClient, InstallationBroker.Config("someClientId", "", "", ""))
+                .onInstall("code", "state")
+
+        Assertions.assertFalse(successReceiver.executed)
+        Assertions.assertFalse(errorReceiver.executed)
+
+        Assertions.assertEquals(0.0, meterRegistry.get("slack.installation.success").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.installation.error").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.installation.count").counter().count())
+        Assertions.assertEquals(0.0, meterRegistry.get("slack.installation.receiver.executions").counter().count())
+        Assertions.assertEquals(0.0, meterRegistry.get("slack.installation.receiver.errors").counter().count())
+    }
+
+
+    class SuccessReceiver : InstallationReceiver {
+
+        var executed: Boolean = false
+
+        override fun onReceiveInstallation(code: String, state: String, team: Team) {
+            executed = true
+        }
+    }
+
+    class ErrorReceiver : InstallationReceiver {
+
+        var executed: Boolean = false
+
+        override fun onReceiveInstallation(code: String, state: String, team: Team) {
+            executed = true
+            throw IllegalStateException("Failure Test")
+        }
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/InteractiveComponentBrokerTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/broker/InteractiveComponentBrokerTests.kt
@@ -1,0 +1,84 @@
+package io.olaph.slack.broker.broker
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.olaph.slack.broker.extensions.sample
+import io.olaph.slack.broker.metrics.InteractiveComponentMetrics
+import io.olaph.slack.broker.receiver.InteractiveComponentReceiver
+import io.olaph.slack.broker.store.InMemoryTeamStore
+import io.olaph.slack.broker.store.Team
+import io.olaph.slack.dto.jackson.InteractiveComponentResponse
+import io.olaph.slack.dto.jackson.sample
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+
+@DisplayName("Event Broker Tests")
+class InteractiveComponentBrokerTests {
+
+
+    @Test
+    @DisplayName("Broker Test")
+    fun brokerTest() {
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val metrics = InteractiveComponentMetrics()
+
+        val meterRegistry = SimpleMeterRegistry()
+        metrics.bindTo(meterRegistry)
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+        val componentResponse = InteractiveComponentResponse.sample().copy(team = InteractiveComponentResponse.Team.sample().copy(id = "TestId"))
+
+        InteractiveComponentBroker(listOf(successReceiver, errorReceiver), teamStore, metrics).receiveEvents(componentResponse, HttpHeaders.EMPTY)
+
+        Assertions.assertTrue(successReceiver.executed)
+        Assertions.assertTrue(errorReceiver.executed)
+
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.interactive.received").counter().count())
+        Assertions.assertEquals(2.0, meterRegistry.get("slack.interactive.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, meterRegistry.get("slack.interactive.receiver.errors").counter().count())
+    }
+
+
+    @Test
+    @DisplayName("Broker Test Without Metrics")
+    fun brokerTestWithoutMetrics() {
+
+        val teamStore = InMemoryTeamStore()
+
+        teamStore.put(Team.sample().copy(teamId = "TestId"))
+
+        val successReceiver = SuccessReceiver()
+        val errorReceiver = ErrorReceiver()
+
+        val componentResponse = InteractiveComponentResponse.sample().copy(team = InteractiveComponentResponse.Team.sample().copy(id = "TestId"))
+
+        InteractiveComponentBroker(listOf(successReceiver, errorReceiver), teamStore).receiveEvents(componentResponse, HttpHeaders.EMPTY)
+
+        Assertions.assertTrue(successReceiver.executed)
+        Assertions.assertTrue(errorReceiver.executed)
+    }
+
+    class SuccessReceiver : InteractiveComponentReceiver {
+        var executed: Boolean = false
+
+        override fun onReceiveInteractiveMessage(interactiveComponentResponse: InteractiveComponentResponse, headers: HttpHeaders, team: Team) {
+            executed = true
+        }
+    }
+
+    class ErrorReceiver : InteractiveComponentReceiver {
+        var executed: Boolean = false
+
+        override fun onReceiveInteractiveMessage(interactiveComponentResponse: InteractiveComponentResponse, headers: HttpHeaders, team: Team) {
+            executed = true
+            throw IllegalStateException("Failing Test Case")
+        }
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/extensions/TeamStoreTestExtension.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/extensions/TeamStoreTestExtension.kt
@@ -1,0 +1,9 @@
+package io.olaph.slack.broker.extensions
+
+import io.olaph.slack.broker.store.Team
+
+fun Team.Companion.sample(): Team = Team("TestTeamId", "TestTeamName", Team.IncomingWebhook.sample(), Team.Bot.sample())
+
+fun Team.IncomingWebhook.Companion.sample(): Team.IncomingWebhook = Team.IncomingWebhook("TestChannel", "TestChannelId", "http://configuration-test.com", "http://test.com")
+
+fun Team.Bot.Companion.sample(): Team.Bot = Team.Bot("UserId", "acccessToken")

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/CommandMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/CommandMetricsTests.kt
@@ -1,0 +1,29 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+class CommandMetricsTests {
+
+    @Test
+    @DisplayName("Comamnd MetricsTests")
+    fun testCommandMetrics() {
+
+        val metrics = CommandMetrics()
+        val simpleMeterRegistry = SimpleMeterRegistry()
+
+        metrics.bindTo(simpleMeterRegistry)
+
+        metrics.commandsReceived()
+        metrics.receiverExecuted()
+        metrics.receiverExecutionError()
+
+
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.commands.received").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.commands.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.commands.receiver.errors").counter().count())
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/EventMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/EventMetricsTests.kt
@@ -1,0 +1,29 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class EventMetricsTests {
+
+
+    @Test
+    @DisplayName("Event MetricsTests")
+    fun testEventMetrics() {
+
+        val metrics = EventMetrics()
+        val simpleMeterRegistry = SimpleMeterRegistry()
+
+        metrics.bindTo(simpleMeterRegistry)
+
+        metrics.eventsReceived()
+        metrics.receiverExecuted()
+        metrics.receiverExecutionError()
+
+
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.events.received").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.events.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.events.receiver.errors").counter().count())
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InstallationMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InstallationMetricsTests.kt
@@ -20,10 +20,14 @@ class InstallationMetricsTests {
         metrics.installationAttempt()
         metrics.errorDuringInstallation()
         metrics.successfulInstallation()
+        metrics.receiverExecuted()
+        metrics.receiverExecutionError()
 
 
         Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.success").counter().count())
         Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.error").counter().count())
         Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.count").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.receiver.errors").counter().count())
     }
 }

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InstallationMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InstallationMetricsTests.kt
@@ -1,0 +1,29 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+class InstallationMetricsTests {
+
+    @DisplayName("Installation MetricsTests")
+    @Test
+    fun testInstallationMetrics() {
+
+        val metrics = InstallationMetrics()
+        val simpleMeterRegistry = SimpleMeterRegistry()
+
+        metrics.bindTo(simpleMeterRegistry)
+
+        metrics.installationAttempt()
+        metrics.errorDuringInstallation()
+        metrics.successfulInstallation()
+
+
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.success").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.error").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.installation.count").counter().count())
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetricsTests.kt
@@ -1,0 +1,29 @@
+package io.olaph.slack.broker.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+class InteractiveComponentMetricsTests {
+    
+    @DisplayName("InteractiveComponent MetricsTests")
+    @Test
+    fun testInteractiveComponentMetrics() {
+
+        val metrics = InteractiveComponentMetrics()
+        val simpleMeterRegistry = SimpleMeterRegistry()
+
+        metrics.bindTo(simpleMeterRegistry)
+
+        metrics.responseReceived()
+        metrics.receiverExecuted()
+        metrics.receiverExecutionError()
+
+
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.interactive.received").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.interactive.receiver.executions").counter().count())
+        Assertions.assertEquals(1.0, simpleMeterRegistry.get("slack.interactive.receiver.errors").counter().count())
+    }
+}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetricsTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/metrics/InteractiveComponentMetricsTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 
 class InteractiveComponentMetricsTests {
-    
+
     @DisplayName("InteractiveComponent MetricsTests")
     @Test
     fun testInteractiveComponentMetrics() {

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/store/InMemoryTeamStoreTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/store/InMemoryTeamStoreTests.kt
@@ -1,0 +1,36 @@
+package io.olaph.slack.broker.store
+
+import io.olaph.slack.broker.extensions.sample
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("InMemoryTeamStore")
+class InMemoryTeamStoreTests {
+
+
+    @DisplayName("Test Add and Remove")
+    @Test
+    fun addAndRemoveTeam() {
+
+        val inMemoryTeamStore = InMemoryTeamStore()
+        inMemoryTeamStore.put(Team.sample().copy(teamId = "TestTeamId"))
+
+        assertEquals(Team.sample().copy(teamId = "TestTeamId"), inMemoryTeamStore.findById("TestTeamId"))
+
+        inMemoryTeamStore.removeById("TestTeamId")
+        assertThrows(TeamNotFoundException::class.java) { inMemoryTeamStore.findById("TestTeamId") }
+
+    }
+
+    @DisplayName("Remove Non Existent")
+    @Test
+    fun removeNonExistent() {
+
+        val inMemoryTeamStore = InMemoryTeamStore()
+        assertDoesNotThrow { inMemoryTeamStore.removeById("NonExistentTeamId") }
+
+    }
+}


### PR DESCRIPTION
solves #148 

Adds Installation Metrics
- total installation attempts
- successful installations
- error during installations

Adds Event Metrics
- events received
- event receiver executions
- event receiver executions failures

Adds Command Metrics
- commands received
- command receiver executions
- command receiver executions failures

Adds InteractiveComponent Metrics
- component responses received
- component response receiver executions
- component response receiver executions failures




## Notes
- Added the propdeps plugin to allow true optional dependencies
- Autoconfiguration of metrics depends on the spring boot actuator framework and is optional
